### PR TITLE
giving dummy argument to generics.h for C11 bindings

### DIFF
--- a/include/shmem/generics.h
+++ b/include/shmem/generics.h
@@ -43,7 +43,7 @@
  * This stops the not-a-context case turning into an error when
  * the value type doesn't match anything
  */
-inline static void shmem_generics_nomatch(...) {}
+inline static void shmem_generics_nomatch(void* dummy, ...) {}
 
 /**
  * @brief Get numbered args out of parameter list


### PR DESCRIPTION
Having (...) on its own in C11 bindings creates compiler errors. This is a quick hack in case C11 bindings are still on the TODO list.