### PR TITLE
Feature/pe quiet

### DIFF
--- a/include/shmem/api.h
+++ b/include/shmem/api.h
@@ -1318,6 +1318,29 @@ void shmem_fence(void);
 void shmem_ctx_quiet(shmem_ctx_t ctx);
 void shmem_quiet(void);
 
+
+/**
+ * @brief causes outbound communication to complete before
+ * subsequent puts are sent for a subset of PEs.
+ * @page shmem_ctx_quiet
+ * @section Synopsis
+ *
+ * @subsection c C/C++
+ @code
+ void shmem_ctx_pe_quiet(shmem_ctx_t ctx, const int *target_pes, size_t npes);
+ void shmem_pe_quiet(const int *target_pes, size_t npes);
+ @endcode
+ *
+ * @section Effect
+ * Remote completion
+ *
+ * @section Return
+ * None.
+ *
+ */
+ void shmem_ctx_pe_quiet(shmem_ctx_t ctx, const int *target_pes, size_t npes);
+ void shmem_pe_quiet(const int *target_pes, size_t npes);
+
 ////////////////////////////////////////////////////////////////////////////////
 /*
  * accessibility

--- a/src/api/quiet.c
+++ b/src/api/quiet.c
@@ -57,3 +57,45 @@ void shmem_quiet(void) {
 
   SHMEMT_MUTEX_NOPROTECT(shmemc_ctx_quiet(SHMEM_CTX_DEFAULT));
 }
+
+/**
+ * @brief Ensures completion of all remote memory updates issued to a context
+ * for a subset of PEs
+ *
+ * This operation ensures completion of all remote memory updates issued to a
+ * specific context prior to this call.
+ *
+ * @param ctx   The context on which to ensure completion of updates
+ */
+void shmem_ctx_pe_quiet(shmem_ctx_t ctx, const int *target_pes, size_t npes) {
+  logger(LOG_QUIET, "%s(ctx=%lu)", __func__, shmemc_context_id(ctx));
+
+  if (npes == 0){
+    return;
+  }
+  for (size_t i = 0; i < npes; i++){
+    SHMEMU_CHECK_PE_ARG_RANGE(target_pes[i], 2);
+  }
+  SHMEMT_MUTEX_NOPROTECT(shmemc_ctx_pe_quiet(ctx, target_pes, npes));
+}
+
+/**
+ * @brief Ensures completion of all remote memory updates issued for a subset
+ * of PEs
+ *
+ * This operation ensures completion of all remote memory updates issued to a
+ * specific context prior to this call.
+ *
+ * @param ctx   The context on which to ensure completion of updates
+ */
+void shmem_pe_quiet(const int *target_pes, size_t npes) {
+  logger(LOG_QUIET, "%s()", __func__);
+
+  if (npes == 0){
+    return;
+  }
+  for (size_t i = 0; i < npes; i++){
+    SHMEMU_CHECK_PE_ARG_RANGE(target_pes[i], 1);
+  }
+  SHMEMT_MUTEX_NOPROTECT(shmemc_ctx_pe_quiet(SHMEM_CTX_DEFAULT, target_pes, npes));
+}

--- a/src/shmemc/shmemc.h
+++ b/src/shmemc/shmemc.h
@@ -72,6 +72,7 @@ void shmemc_progress(void);
 
 void shmemc_ctx_fence(shmem_ctx_t ctx);
 void shmemc_ctx_quiet(shmem_ctx_t ctx);
+void shmemc_ctx_pe_quiet(shmem_ctx_t ctx, const int *target_pes, size_t npes);
 
 #ifdef ENABLE_EXPERIMENTAL
 

--- a/src/shmemc/ucx/comms.c
+++ b/src/shmemc/ucx/comms.c
@@ -14,6 +14,7 @@
 
 #include "shmem/defs.h"
 
+#include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
 
@@ -224,6 +225,45 @@ void shmemc_ctx_quiet(shmem_ctx_t ctx) {
                     ucs_status_string(s));
     }
   }
+}
+
+void shmemc_ctx_pe_quiet(shmem_ctx_t ctx, const int *target_pes, size_t npes) {
+  if (ctx == SHMEM_CTX_INVALID) {
+    return;
+  }
+
+  shmemc_context_h ch = (shmemc_context_h)ctx;
+  if (ch->attr.nostore) {
+    return;
+  }
+
+#ifdef HAVE_UCP_EP_FLUSH_NBX
+  const ucp_request_param_t prm = {.op_attr_mask =
+                                       UCP_OP_ATTR_FIELD_CALLBACK,
+                                   .cb.send = noop_callbackx};
+
+  ucs_status_ptr_t *reqs = malloc(npes * sizeof(*reqs));
+  shmemu_assert(reqs != NULL, MODULE ": %s() failed to allocate request array",
+                __func__);
+
+  for (size_t i = 0; i < npes; i++) {
+    reqs[i] = ucp_ep_flush_nbx(ch->eps[target_pes[i]], &prm);
+  }
+
+  for (size_t i = 0; i < npes; i++) {
+    const ucs_status_t s = check_wait_for_request(ch, reqs[i]);
+    shmemu_assert(s == UCS_OK, MODULE ": %s() failed (status: %s)", __func__,
+                  ucs_status_string(s));
+  }
+
+  free(reqs);
+#else
+  for (size_t i = 0; i < npes; i++) {
+    s = ucp_worker_flush(ch->w);
+    shmemu_assert(s == UCS_OK, MODULE ": %s() failed (status: %s)", __func__,
+                  ucs_status_string(s));
+  }
+#endif /* HAVE_UCP_EP_FLUSH_NBX */
 }
 
 #ifdef ENABLE_EXPERIMENTAL

--- a/src/shmemc/ucx/comms.c
+++ b/src/shmemc/ucx/comms.c
@@ -238,9 +238,7 @@ void shmemc_ctx_pe_quiet(shmem_ctx_t ctx, const int *target_pes, size_t npes) {
   }
 
 #ifdef HAVE_UCP_EP_FLUSH_NBX
-  const ucp_request_param_t prm = {.op_attr_mask =
-                                       UCP_OP_ATTR_FIELD_CALLBACK,
-                                   .cb.send = noop_callbackx};
+  const ucp_request_param_t prm = {.op_attr_mask = 0};
 
   ucs_status_ptr_t *reqs = malloc(npes * sizeof(*reqs));
   shmemu_assert(reqs != NULL, MODULE ": %s() failed to allocate request array",

--- a/src/shmemc/ucx/eps.c
+++ b/src/shmemc/ucx/eps.c
@@ -87,7 +87,7 @@ static void ep_wait(shmemc_context_h ch, ucs_status_ptr_t req) {
  */
 
 void shmemc_ucx_disconnect_all_eps(shmemc_context_h ch) {
-  int i;
+  int i; 
   ucs_status_ptr_t *reqs;
 
   reqs = (ucs_status_ptr_t *)malloc(proc.li.nranks * sizeof(*reqs));


### PR DESCRIPTION
Addition of the shmem_pe_quiet and the shmem_ctx_pe_quiet routines for openshmem 1.6. 

Uses non-blocking ucx calls to schedule all ucp flush operations at once for each PE, then sequentially ensures completion of ucp flush operations. 